### PR TITLE
Do not run makemigrations  when `--cached` option is used

### DIFF
--- a/reset_migrations/management/commands/reset_migrations.py
+++ b/reset_migrations/management/commands/reset_migrations.py
@@ -76,7 +76,8 @@ class Command(BaseCommand):
                 self.delete_dependence_app(app)
             self.stdout.write("APP (%s) deleted with sucess" % app)
 
-        call_command('makemigrations', *apps)
+        if not options['cached']:
+            call_command('makemigrations', *apps)
 
         for app in apps:
             call_command('migrate', app, '--fake')


### PR DESCRIPTION
I consider `makemigrations` to be unnecessary and dangerous when the `--cached` option is used. After all there shouldn't be any pending changes before running this command. Otherwise we would be fake-applying those pending migrations and that might leave the DB in an inconsistent state.

When the `--cached` option is used, the command should only clean the migrations table and fake-apply the existing migration files.